### PR TITLE
Improve documentation & cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,7 @@
 .env
 .env.test
 .env.dev
+
+# Ignore generated documentation
+/doc
+/.yardoc

--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,7 @@
+--protected
+--no-private
+--readme           README.md
+--markup           markdown
+--markup-provider  kramdown
+-
+LICENCE

--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,7 @@ gem 'minitest'
 #= BDD Tools =========================================================
 group :doc do
   # bundle exec rake doc:rails generates the API under doc/api.
-  gem 'sdoc', require: false
+  gem 'yard'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -226,8 +226,6 @@ GEM
     rb-fsevent (0.9.7)
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)
-    rdoc (4.2.1)
-      json (~> 1.4)
     redcarpet (3.3.4)
     responders (2.1.1)
       railties (>= 4.2.0, < 5.1)
@@ -264,9 +262,6 @@ GEM
       sass (~> 3.2.2)
       sprockets (~> 2.8, < 3.0)
       sprockets-rails (~> 2.0)
-    sdoc (0.4.1)
-      json (~> 1.7, >= 1.7.7)
-      rdoc (~> 4.0)
     shellany (0.0.1)
     shoulda-matchers (3.0.1)
       activesupport (>= 4.0.0)
@@ -309,6 +304,7 @@ GEM
     will_paginate (3.0.7)
     xpath (2.0.0)
       nokogiri (~> 1.3)
+    yard (0.9.5)
 
 PLATFORMS
   ruby
@@ -349,7 +345,6 @@ DEPENDENCIES
   rspec-its
   rspec-rails (~> 3.3.3)
   sass-rails (~> 4.0.3)
-  sdoc
   shoulda-matchers (~> 3.0)
   simple_form (~> 3.1.1)
   simplecov
@@ -360,6 +355,7 @@ DEPENDENCIES
   timezone (~> 0.4.2)
   uglifier (~> 2.5.0)
   will_paginate (~> 3.0.7)
+  yard
 
 RUBY VERSION
    ruby 2.1.5p273

--- a/app/assets/javascripts/stations/graph.js
+++ b/app/assets/javascripts/stations/graph.js
@@ -51,20 +51,24 @@ $(function(){
             dataType: 'JSON',
             ifModified: true,
             success: function(data, textStatus, jqXHR){
-                // Status is 200 OK
-                if (data && data.length) {
-                    $graph.trigger('graph.render', [data]);
-                }
+              $graph.parents('.chart-wrapper').find("alert-box").remove();
+              if (textStatus = "200" && data.length) {
+                  $graph.show();
+                  $graph.trigger('graph.render', [data]);
+              } else {
+                 $graph.parents('.chart-wrapper').prepend('<div class="alert-box alert">No recent data available :|</div>')
+                 $graph.hide();
+              }
 
-                // Read max_age from Cache-Control header
-                var max_age = (function(cc) {
-                    return parseInt(cc.match(/max-age=(\d*),/).pop());
-                }(jqXHR.getResponseHeader('Cache-Control') || refresh));
+              // Read max_age from Cache-Control header
+              var max_age = (function(cc) {
+                  return parseInt(cc.match(/max-age=(\d*),/).pop());
+              }(jqXHR.getResponseHeader('Cache-Control') || refresh));
 
-                // Fetch new observations when max_age has expired
-                window.setTimeout(function() {
-                    $graph.trigger('graph.data.load');
-                }, max_age * 1000);
+              // Fetch new observations when max_age has expired
+              window.setTimeout(function() {
+                  $graph.trigger('graph.data.load');
+              }, max_age * 1000);
             }
         });
     });

--- a/app/assets/javascripts/stations/map.js.erb
+++ b/app/assets/javascripts/stations/map.js.erb
@@ -5,9 +5,12 @@ $(document).ready(function(){
     var $map_canvas = $('#map_canvas');
 
     if ($map_canvas.length) {
-      google.load("maps", "3", { other_params:'sensor=false', callback: function(){
+      google.load("maps", "3", {
+        other_params:'key=AIzaSyADjhLKyBDLO7QwMSSZJChP2IUSsL52wNw',
+        callback: function(){
           apiLoaded.resolve(google);
-      }});
+        }
+      });
     }
 
     // Initialize map

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,17 +19,6 @@ class ApplicationController < ActionController::Base
   # or a page with authorized features missing.
   etag { user_signed_in? ? current_user.id : 0 }
 
-
-  # Tell devise to redirect to root instead of user#show
-  def after_sign_in_path_for(resource)
-    root_path
-  end
-
-  # Overwriting the sign_out redirect path method
-  def after_sign_out_path_for(resource_or_scope)
-    root_path
-  end
-
   # Setup geonames user name
   Timezone::Configure.begin do |c|
     c.username = ENV['REMOTE_WIND_GEONAMES']
@@ -55,44 +44,46 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  # Get notifications
-  #@todo load with ajax instead
-  def get_notifications
-    count = Notification.where(user: current_user, read: false).count
-    if count > 0
-      flash[:notice] = view_context.link_to(
-          "You have #{pluralize(count, 'unread notification')}.", user_notifications_path(user_id: current_user)
-      )
-      @unread_notifications_count = count
+  private
+
+    # Get notifications
+    #@todo load with ajax instead
+    def get_notifications
+      count = Notification.where(user: current_user, read: false).count
+      if count > 0
+        flash[:notice] = view_context.link_to(
+            "You have #{pluralize(count, 'unread notification')}.", user_notifications_path(user_id: current_user)
+        )
+        @unread_notifications_count = count
+      end
     end
-  end
 
-  # ActiveRecord::Serializers
-  # Don´t emit node per default when serializing
-  # Example:
-  # @apple = Apple.new(type: 'Macintosh')
-  # render json: @apple
-  # Renders:
-  # {"type": "Macintosh"}
-  def default_serializer_options
-    {root: false}
-  end
+    # Tell devise to redirect to root instead of user#show
+    def after_sign_in_path_for(resource)
+      root_path
+    end
 
-  protected
+    # Overwriting the sign_out redirect path method
+    def after_sign_out_path_for(resource_or_scope)
+      root_path
+    end
 
-  # Enables cross-origin resource sharing for action.
-  # @see http://enable-cors.org/index.html
-  # @see https://github.com/remote-wind/remote-wind/issues/94
-  # @param allow_origin [String]
-  # @param allow_methods [String]
-  # @param allow_headers [String]
-  def make_public(
-    origin: '*',
-    methods: 'GET, OPTIONS',
-    headers: 'Origin, X-Requested-With, Content-Type, Accept, Authorization'
-  )
-    self.headers['Access-Control-Allow-Origin'] = origin
-    self.headers['Access-Control-Allow-Methods'] = methods
-    self.headers['Access-Control-Allow-Headers'] = headers
-  end
+    # ActiveRecord::Serializers
+    # Don´t emit node per default when serializing
+    def default_serializer_options
+      {root: false}
+    end
+
+    # Enables cross-origin resource sharing for action.
+    # @see http://enable-cors.org/index.html
+    # @see https://github.com/remote-wind/remote-wind/issues/94
+    def make_public(
+      origin: '*',
+      methods: 'GET, OPTIONS',
+      headers: 'Origin, X-Requested-With, Content-Type, Accept, Authorization'
+    )
+      self.headers['Access-Control-Allow-Origin'] = origin
+      self.headers['Access-Control-Allow-Methods'] = methods
+      self.headers['Access-Control-Allow-Headers'] = headers
+    end
 end

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -1,3 +1,4 @@
+# Handles in-app notifications for station events.
 class NotificationsController < ApplicationController
 
   authorize_resource
@@ -65,13 +66,13 @@ class NotificationsController < ApplicationController
     redirect_to action: :index
   end
 
-  def set_user
-    # Avoid DB query if user is current_user
-    if [current_user.to_param, current_user.id.to_s].include?(params[:user_id])
-      @user = current_user
-    else
-      @user = User.friendly.find(params[:user_id])
+  private
+    def set_user
+      # Avoid DB query if user is current_user
+      if [current_user.to_param, current_user.id.to_s].include?(params[:user_id])
+        @user = current_user
+      else
+        @user = User.friendly.find(params[:user_id])
+      end
     end
-  end
-
 end

--- a/app/controllers/observations_controller.rb
+++ b/app/controllers/observations_controller.rb
@@ -11,6 +11,9 @@ class ObservationsController < ApplicationController
   # Could possible be moved to a job after Rails 5 update.
   after_action ->{ @station.check_status! unless @station.nil? }, only: :create
 
+  # @todo CLEANUP
+  #   since the legacy Ardiuno routes which do not include the :station_id
+  #   i think we can safely assume the presence of the station.
   # POST /observations
   def create
     # Find station via ID or SLUG
@@ -69,14 +72,13 @@ class ObservationsController < ApplicationController
 
   private
 
+    # get station with Friendly ID as params[:id] can either be id or slug
     def set_station
-      # get station with Friendly Id, params[:id] can either be id or slug
+
       @station = Station.friendly.find(params[:station_id])
     end
 
-    # Never trust parameters from the scary internet, only allow the white list through.
     def observation_params
-      logger.info "Observation Controller with params: " + params.to_s
       params.require(:observation).permit(
           :id, :station_id, :direction, :speed, :min_wind_speed, :max_wind_speed
       )

--- a/app/controllers/observations_controller.rb
+++ b/app/controllers/observations_controller.rb
@@ -7,7 +7,8 @@ class ObservationsController < ApplicationController
   before_action :set_station, only: [:index, :clear, :create]
   before_action :make_public, only: [:index] # Sets CORS headers to allow cross-site sharing
 
-  # Send response first when creating an observation.
+  # Checks the up/down heuristics after creating an observation.
+  # Could possible be moved to a job after Rails 5 update.
   after_action ->{ @station.check_status! unless @station.nil? }, only: :create
 
   # POST /observations
@@ -84,7 +85,7 @@ class ObservationsController < ApplicationController
     def expiry_time(station)
       t = station.next_observation_expected_in
       # checks if station is overdue for reporting in which case it sets the
-      # expiry to 1 minute to encourage the client to check again.
+      # expiry to 1 minute to encourage the client (browser) to check again.
       t > 0 ? t : 1.minute
     end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,3 +1,4 @@
+# Handles relativly static pages 
 class PagesController < ApplicationController
 
   skip_before_filter :authenticate_user!

--- a/app/controllers/stations_controller.rb
+++ b/app/controllers/stations_controller.rb
@@ -89,7 +89,6 @@ class StationsController < ApplicationController
     end
   end
 
-  # @throws ActiveRecord::RecordNotFound if no station
   # PUT /s/:station_id
   def update_balance
     sp = params.require(:s).permit(:b)
@@ -168,24 +167,24 @@ class StationsController < ApplicationController
 
   private
 
-  def no_cache
-    response.headers["Cache-Control"] = "no-cache, no-store, must-revalidate" # HTTP 1.1.
-    response.headers["Pragma"] = "no-cache" # HTTP 1.0.
-    response.headers["Expires"] = "0" # Proxies.
-  end
+    def no_cache
+      response.headers["Cache-Control"] = "no-cache, no-store, must-revalidate" # HTTP 1.1.
+      response.headers["Pragma"] = "no-cache" # HTTP 1.0.
+      response.headers["Expires"] = "0" # Proxies.
+    end
 
-  # before_action
-  def set_station
-    @station = Station.friendly.find(params[:id])
-    logger.info action_name.to_sym
-    authorize! @station, action_name.to_sym unless (action_name.to_sym).in?([:embed, :show, :update_balance, :api_firmware_version])
-  end
+    # before_action
+    def set_station
+      @station = Station.friendly.find(params[:id])
+      logger.info action_name.to_sym
+      authorize! @station, action_name.to_sym unless (action_name.to_sym).in?([:embed, :show, :update_balance, :api_firmware_version])
+    end
 
-  # Never trust parameters from the scary internet, only allow the white list through.
-  def station_params
-    params.require(:station).permit(
-      :name, :hw_id, :latitude, :longitude, :user_id, :slug,
-      :show, :speed_calibration, :description, :sampling_rate
-    )
-  end
+    # Never trust parameters from the scary internet, only allow the white list through.
+    def station_params
+      params.require(:station).permit(
+        :name, :hw_id, :latitude, :longitude, :user_id, :slug,
+        :show, :speed_calibration, :description, :sampling_rate
+      )
+    end
 end

--- a/app/controllers/stations_controller.rb
+++ b/app/controllers/stations_controller.rb
@@ -184,7 +184,8 @@ class StationsController < ApplicationController
   # Never trust parameters from the scary internet, only allow the white list through.
   def station_params
     params.require(:station).permit(
-      :name, :hw_id, :latitude, :longitude, :user_id, :slug, :show, :speed_calibration, :description
+      :name, :hw_id, :latitude, :longitude, :user_id, :slug,
+      :show, :speed_calibration, :description, :sampling_rate
     )
   end
 end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,3 +1,4 @@
+# Handles callbacks when signing in via OAuth
 class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
   skip_before_filter :verify_authenticity_token

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,4 +1,6 @@
-# Override verify_authenticity_token to prevent InvalidAuthenticationToken issues when using omniauth
+# Users registered via OAuth don't have a password
+# So we need to override the update method so that they can update their account
+# without providing a password
 class Users::RegistrationsController < Devise::RegistrationsController
 
   def create
@@ -6,10 +8,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
   end
 
   def update
-    # For Rails 4
     account_update_params = devise_parameter_sanitizer.sanitize(:account_update)
-    # For Rails 3
-    # account_update_params = params[:user]
 
     # required for settings form to submit when password is left blank
     if account_update_params[:password].blank?

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,3 +1,5 @@
+# This provides addional actions for users in addition to [Devise::Registrations]
+# for example adding and removing roles from users.
 class UsersController < ApplicationController
   before_filter :authenticate_user!, except: [:show, :index]
   before_filter :set_user, except: [:index]
@@ -44,13 +46,13 @@ class UsersController < ApplicationController
     end
   end
 
-  protected
+  private
 
-  def set_user
-    @user = User.friendly.find(params[:id])
-  end
+    def set_user
+      @user = User.friendly.find(params[:id])
+    end
 
-  def update_params
-    params.require(:user).permit(:email, role_ids: [])
-  end
+    def update_params
+      params.require(:user).permit(:email, role_ids: [])
+    end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,5 +1,6 @@
 module ApplicationHelper
-
+  # Renders dynamic page titles
+  # @return String
   def title
     if @title.nil?
       "Remote Wind"
@@ -7,5 +8,4 @@ module ApplicationHelper
       "#{@title} | Remote Wind"
     end
   end
-
 end

--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -1,7 +1,8 @@
+# Used for the text/plain segment of multipart emails.
 module MarkdownHelper
-
+  # Used when parsing to create email friendly links
+  # @return [String]
   def MarkdownHelper.link_to(name, url)
     "[#{name}](#{url})"
   end
-
 end

--- a/app/helpers/notifications_helper.rb
+++ b/app/helpers/notifications_helper.rb
@@ -45,5 +45,4 @@ module NotificationsHelper
   def notification_timestamp(note)
     time_date_hours_seconds( @user.to_local_time( note.created_at ) )
   end
-
 end

--- a/app/helpers/observations_helper.rb
+++ b/app/helpers/observations_helper.rb
@@ -1,27 +1,43 @@
 module ObservationsHelper
-
-  def degrees_and_cardinal degrees
+  # Used to display both the cardinal (general compass direction)
+  # and degrees from north
+  # @param degrees [FixNum]
+  # @example degrees_and_cardinal(90)
+  #  =>  "E (90°)"
+  # @return [String]
+  def degrees_and_cardinal(degrees)
     if degrees
       "%s (%d°)" % [Geocoder::Calculations.compass_point(degrees), degrees]
     end
   end
 
+  # Makes a formatted string for displaying wind speed.
+  # @param []
+  # @return [String]
+  # @example speed_min_max( Observation.new(speed: 5, min: 2, max: 7) )
+  #   => "5 (2-7)m/s"
   def speed_min_max(observation)
-
     unless observation.is_a? Hash
       observation = HashWithIndifferentAccess.new(observation.attributes)
     end
-
     if observation
       "%{speed} (%{min_wind_speed}-%{max_wind_speed})m/s" % observation
     end
   end
 
-  def time_in_24h time
+  # Display a time in 24h format.
+  # @todo FIX - this does not properly handle timezones
+  # @param time [DateTime|Time|TimeWithZone]
+  # @return [String]
+  def time_in_24h(time)
     time.strftime("%H:%M")
   end
 
-  def time_date_hours_seconds time
-    time.today? ? time.strftime("%H:%M") : time.strftime("%m/%d %H:%M")
+  # Display a time and the date unless the time is during the current day.
+  # @todo FIX - this does not properly handle timezones
+  # @param time [DateTime|Time|TimeWithZone]
+  # @return [String]
+  def time_date_hours_seconds(time)
+    time.today? ? time_in_24h(time) : time.strftime("%m/%d %H:%M")
   end
 end

--- a/app/helpers/pagination_helper.rb
+++ b/app/helpers/pagination_helper.rb
@@ -1,43 +1,42 @@
 module PaginationHelper
 
+  # Helper method to output Zurb Foundation compatible pagination.
   def foundation_paginate(pages, options = {})
-    options.reverse_merge!({
+    will_paginate(pages, options.reverse_merge({
        class: 'pagination',
        inner_window: 2,
        outer_window: 0,
        renderer: PaginationHelper::FoundationPaginationListLinkRenderer,
        previous_label: '&laquo;'.html_safe,
        next_label: '&raquo;'.html_safe
-    })
-    will_paginate(pages, options)
+    }))
   end
 
-  # Override the will_paginate link renderer to create better  markup that works with foundations pagination CSS
+  # Override the will_paginate link renderer to create
+  # markup that fits the Zurb Foundation pagination components
   # http://thewebfellas.com/blog/2010/8/22/revisited-roll-your-own-pagination-links-with-will_paginate-and-rails-3
   class FoundationPaginationListLinkRenderer < WillPaginate::ActionView::LinkRenderer
 
     protected
 
-    def gap
-      tag :li, link(super, '#'), class: 'unavailable'
-    end
+      def gap
+        tag :li, link(super, '#'), class: 'unavailable'
+      end
 
-    def page_number(page)
-      tag :li, link(page, page, rel: rel_value(page)), class: ('current' if page == current_page)
-    end
+      def page_number(page)
+        tag :li, link(page, page, rel: rel_value(page)), class: ('current' if page == current_page)
+      end
 
-    def previous_or_next_page(page, text, classname)
-      tag :li, link(text, page || '#'), class: [classname[0..3], classname, ('unavailable' unless page)].join(' ')
-    end
+      def previous_or_next_page(page, text, classname)
+        tag :li, link(text, page || '#'), class: [classname[0..3], classname, ('unavailable' unless page)].join(' ')
+      end
 
-    def html_container(html)
-      tag(:ul, html, container_attributes)
-    end
+      def html_container(html)
+        tag(:ul, html, container_attributes)
+      end
 
-    def gap
-      tag :li, link(super, '#'), class: 'unavailable'
-    end
-
+      def gap
+        tag :li, link(super, '#'), class: 'unavailable'
+      end
   end
-
 end

--- a/app/helpers/stations_helper.rb
+++ b/app/helpers/stations_helper.rb
@@ -1,9 +1,9 @@
 module StationsHelper
 
   # Create link to clear observations for station
-  #@param station Station
-  #@param options Hash
-  #@return string
+  # @param station [Station]
+  # @param options [Hash]
+  # @return [String]
   def clear_observations_button(station, options = {})
     options.merge!({
         text: "Clear all observations for this station?",
@@ -16,17 +16,34 @@ module StationsHelper
     link_to options[:text], station_observations_path(station), options
   end
 
-  #@param station Station
-  #@return String station name + (offline)
+  # @param station [Station]
+  # @return [String]
+  # @example when online
+  #   station_header(station)
+  #   => "Test station"
+  # @example when offline
+  #   station_header(station)
+  #   => "Test station(<em>offline</em>)"
   def station_header(station)
-    (station.offline? ? station.name + "(#{content_tag(:em, 'offline')})" : station.name).html_safe
+    if station.offline?
+      ( station.name + "(#{content_tag(:em, 'offline')})" ).html_safe
+    else
+      station.name
+    end
   end
 
+  # @todo CLEANUP
+  # @param station [Station]
+  # @return [String]
   def station_coordinates(station)
     sprintf('data-lat="%d" data-lng="%d"', station.latitude, station.longitude).html_safe
   end
 
-
+  # Displays a duration as a digital timer format
+  # @param station [ActiveSupport::Duration]
+  # @return [String]
+  # @example readable_duration(1.hours)
+  #   => "01:30:00"
   def readable_duration(duration)
     Time.at(duration.to_i).utc.strftime("%H:%M:%S")
   end

--- a/app/helpers/stations_helper.rb
+++ b/app/helpers/stations_helper.rb
@@ -27,5 +27,7 @@ module StationsHelper
   end
 
 
-
+  def readable_duration(duration)
+    Time.at(duration.to_i).utc.strftime("%H:%M:%S")
+  end
 end

--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -1,31 +1,37 @@
+# @todo CLEANUP - should not hardcorde TO address
 class AdminMailer < Devise::Mailer
 
-  def notify_about_new_user(resource)
-    @user = resource
-    mail :to => "info@yelloworb.com", :subject => "New user registered at remote wind" do |format|
+  #
+  # @param user [User]
+
+  def notify_about_new_user(user)
+    @user = user
+    mail(to:"info@yelloworb.com", subject:"New user registered at remote wind") do |format|
       format.html
     end
   end
-  
+
+  # @todo CLEANUP - can unregistered users still create stations?
+  # I dont think so
   def notify_about_new_station_without_owner(station)
     @station = station
-    mail :to => "info@yelloworb.com", :subject => "New station but now owner set" do |format|
+    mail(to:"info@yelloworb.com", subject:"New station but now owner set") do |format|
       format.html
     end
   end
-  
+
   def notify_about_new_station_and_invitation(email, station)
     @station = station
     @email = email
-    mail :to => "info@yelloworb.com", :subject => "New station created and user invited" do |format|
+    mail(to:"info@yelloworb.com", subject:"New station created and user invited") do |format|
       format.html
     end
   end
-  
+
   def notify_about_new_station(user, station)
     @station = station
     @user = user
-    mail :to => "info@yelloworb.com", :subject => "New station" do |format|
+    mail(to:"info@yelloworb.com", subject:"New station") do |format|
       format.html
     end
   end

--- a/app/mailers/station_mailer.rb
+++ b/app/mailers/station_mailer.rb
@@ -1,12 +1,11 @@
 class StationMailer < ActionMailer::Base
-  # Subject can be set in your I18n file at config/locales/en.yml
-  # with the following lookup:
-  #
-  # en.station_mailer.low_balance.subject
-  # @param station Station
-  # @param options Hash (optional)
-  # @return Mail::Message | nil returns nil if mail could not be created
-  def low_balance station, options = {}
+  # @note Subject should be set via I18n file at config/locales/en.yml
+  #   with the following key:
+  #     en.station_mailer.low_balance.subject
+  # @param station [Station]
+  # @param options [Hash]
+  # @return [Mail::Message|nil] nil if mail could not be created
+  def low_balance(station, options = {})
     @balance = station.balance
     send_mail(station, options.merge!(
         message_handler: __method__,
@@ -14,28 +13,26 @@ class StationMailer < ActionMailer::Base
     ))
   end
 
-  # Subject can be set in your I18n file at config/locales/en.yml
-  # with the following lookup:
-  #
-  # en.station_mailer.offline.subject
-  # @param station Station
-  # @param options Hash (optional)
-  # @return Mail::Message | nil returns nil if mail could not be created
-  def offline station, options = {}
+  # @note Subject should be set via I18n file at config/locales/en.yml
+  #   with the following key:
+  #     en.station_mailer.offline.subject
+  # @param station [Station]
+  # @param options [Hash]
+  # @return [Mail::Message|nil] nil if mail could not be created
+  def offline(station, options = {})
     send_mail(station, options.merge!(
         message_handler: __method__,
         subject: "Your station #{station.name} has not responded for 15 minutes."
     ))
   end
-  
-  # Subject can be set in your I18n file at config/locales/en.yml
-  # with the following lookup:
-  #
-  # en.station_mailer.offline.subject
-  # @param station Station
-  # @param options Hash (optional)
-  # @return Mail::Message | nil returns nil if mail could not be created
-  def online station, options = {}
+
+  # @note Subject should be set via I18n file at config/locales/en.yml
+  #   with the following key:  
+  #     en.station_mailer.offline.subject
+  # @param station [Station]
+  # @param options [Hash]
+  # @return [Mail::Message|nil] nil if mail could not be created
+  def online(station, options = {})
     send_mail(station, options.merge!(
         message_handler: __method__,
         subject: "Your station #{station.name} has started to respond and we are now receiving data from it."
@@ -43,28 +40,27 @@ class StationMailer < ActionMailer::Base
   end
 
   private
-
-  # @param station Station
-  # @param options Hash
-  # @return Mail::Message | nil returns nil if mail could not be created
-  def send_mail(station, options)
-    @station = station
-    @link = MarkdownHelper.link_to(@station.name, station_url(@station.id))
-    options.merge!(
-        to: station.try(:user).try(:email)
-    )
-    message = mail(options) do |format|
-      format.text
-      format.html
-    end
-    options[:message_handler] = "StationMailer##{options[:message_handler].to_s}"
-    if message
-      unless message.deliver
-        Rails.logger.error("#{options[:message_handler]}: Email could not be delivered")
+    # @param station [Station]
+    # @param options [Hash]
+    # @return [Mail::Message|nil] nil if mail could not be created
+    def send_mail(station, options)
+      @station = station
+      @link = MarkdownHelper.link_to(@station.name, station_url(@station.id))
+      options.merge!(
+          to: station.try(:user).try(:email)
+      )
+      message = mail(options) do |format|
+        format.text
+        format.html
       end
-    else
-      Rails.logger.error("#{options[:message_handler]}: Mail could not be created")
+      options[:message_handler] = "StationMailer##{options[:message_handler].to_s}"
+      if message
+        unless message.deliver
+          Rails.logger.error("#{options[:message_handler]}: Email could not be delivered")
+        end
+      else
+        Rails.logger.error("#{options[:message_handler]}: Mail could not be created")
+      end
+      message
     end
-    message
-  end
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,13 +1,13 @@
 class UserMailer < ActionMailer::Base
 
-  # Subject can be set in your I18n file at config/locales/en.yml
-  # with the following lookup:
-  #
-  #   en.user_mailer.test.subject
-  #
-  # @param [User|String] recipient - can be used with a email address or a User
+  # @note Subject should be set via I18n file at config/locales/en.yml
+  #   with the following key:
+  #     en.user_mailer.test.subject
+  # @param recipient [User|String]  - can be used with a email address or a User
+  # @return [Mail::Message|nil] nil if mail could not be created
   def test(recipient)
-    mail to: recipient.is_a?(User) ? recipient.email : recipient do |format|
+    email = recipient.is_a?(User) ? recipient.email : recipient
+    mail(to: email) do |format|
       format.text
       format.html
     end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -1,6 +1,11 @@
+# The Ability model is a centralised place to declare authorization rules
+# This is not an ActiveRecord model but rather initialized by CanCanCan
+# as part of the authorization process.
+# @see https://github.com/CanCanCommunity/cancancan/wiki/defining-abilities
 class Ability
   include CanCan::Ability
 
+  # @param [User] user
   def initialize(user)
     user ||= User.new
 
@@ -34,6 +39,5 @@ class Ability
     if user.has_role? :admin
       can :manage, :all
     end
-
   end
 end

--- a/app/models/authentication_provider.rb
+++ b/app/models/authentication_provider.rb
@@ -1,12 +1,7 @@
-# == Schema Information
-#
-# Table name: authentication_providers
-#
-#  id         :integer          not null, primary key
-#  name       :string(255)
-#  created_at :datetime
-#  updated_at :datetime
-#
+# @todo CLEANUP - evalutate if can be removed
+# @attr name [string]
+# @attr created_at [datetime]
+# @attr updated_at [datetime]
 class AuthenticationProvider < ActiveRecord::Base
   has_many :users
   has_many :user_authentications

--- a/app/models/concerns/slugged.rb
+++ b/app/models/concerns/slugged.rb
@@ -1,6 +1,8 @@
+# Hacky way to select stations by id or slug
+# @todo CLEANUP - can be removed by using friendly_id properly?
 module Slugged
-    def select_by_slug_or_id param
-      station = select { |station| [ station.slug, station.id].include?( param ) }
-      station.first if station.length.nonzero?
-    end
+  def select_by_slug_or_id param
+    station = select { |station| [ station.slug, station.id].include?( param ) }
+    station.first if station.length.nonzero?
+  end
 end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,16 +1,4 @@
-# == Schema Information
-#
-# Table name: notifications
-#
-#  id         :integer          not null, primary key
-#  event      :string(255)
-#  message    :text
-#  user_id    :integer
-#  created_at :datetime
-#  updated_at :datetime
-#  read       :boolean          default(FALSE)
-#  level      :integer
-#
+# Represents an in-app notification message.
 class Notification < ActiveRecord::Base
   belongs_to :user
 

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -1,19 +1,5 @@
-# == Schema Information
-#
-# Table name: observations
-#
-#  id                :integer          not null, primary key
-#  station_id        :integer
-#  speed             :float
-#  direction         :float
-#  max_wind_speed    :float
-#  min_wind_speed    :float
-#  temperature       :float
-#  created_at        :datetime
-#  updated_at        :datetime
-#  speed_calibration :float
-#
-
+# Respresents a series of measurements taken by a weather station.
+# Take extreme care when querying this table as it contrains a lot of rows!
 class Observation < ActiveRecord::Base
 
   belongs_to :station, dependent: :destroy, inverse_of: :observations
@@ -25,11 +11,13 @@ class Observation < ActiveRecord::Base
             numericality: { allow_blank: true }
   validate :observation_cannot_be_calibrated
 
+  # @todo - CLEANUP --
   alias_attribute :i, :station_id
   alias_attribute :s, :speed
   alias_attribute :d, :direction
   alias_attribute :max, :max_wind_speed
   alias_attribute :min, :min_wind_speed
+  # /@todo
   attr_accessor :calibrated
   after_validation :set_calibration_value!
   after_find :calibrate!
@@ -40,26 +28,31 @@ class Observation < ActiveRecord::Base
   scope :since, ->(time) { where("created_at > ?", time) }
   scope :desc, -> { order('created_at DESC') }
 
+  # @todo - CLEANUP
   # when writing from the ardiuno params short form
   def s= val
     write_attribute(:speed, val.to_f / 100)
   end
 
+  # @todo - CLEANUP
   # when writing from the ardiuno params short form
   def d= val
     write_attribute(:direction, (val.to_f / 10).round(0))
   end
 
+  # @todo - CLEANUP
   # when writing from the ardiuno params short form
   def max= val
     write_attribute(:max_wind_speed, val.to_f / 100)
   end
 
+  # @todo - CLEANUP
   # when writing from the ardiuno params short form
   def min= val
     write_attribute(:min_wind_speed, val.to_f / 100)
   end
 
+  # @todo - CLEANUP
   def b=
     write_attribute(:min_wind_speed, val.to_f / 100)
   end

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -1,15 +1,11 @@
-# == Schema Information
-#
-# Table name: roles
-#
-#  id            :integer          not null, primary key
-#  name          :string(255)
-#  resource_id   :integer
-#  resource_type :string(255)
-#  created_at    :datetime
-#  updated_at    :datetime
-#
-
+# This is the normalized table containing the definitions of roles and an
+# association to which the role is scoped.
+# @see https://github.com/RolifyCommunity/rolify
+# @attr name [String]
+# @attr resource_id [Integer]
+# @attr resource_type [String]
+# @attr created_at [DateTime]
+# @attr updated_at [DateTime]
 class Role < ActiveRecord::Base
   has_and_belongs_to_many :users, join_table: :users_roles
   belongs_to :user, polymorphic: true
@@ -17,8 +13,9 @@ class Role < ActiveRecord::Base
 
   AVAILABLE_ROLES = [:admin]
 
+  # Displays a human readable version of the role name
+  # @return [String]
   def display_name
     @name.capitalize
   end
-  
 end

--- a/app/models/station.rb
+++ b/app/models/station.rb
@@ -1,26 +1,23 @@
-# == Schema Information
-#
-# Table name: stations
-#
-#  id                           :integer          not null, primary key
-#  name                         :string(255)
-#  hw_id                        :string(255)
-#  latitude                     :float
-#  longitude                    :float
-#  balance                      :float
-#  offline                      :boolean
-#  timezone                     :string(255)
-#  user_id                      :integer
-#  created_at                   :datetime
-#  updated_at                   :datetime
-#  slug                         :string(255)
-#  show                         :boolean          default(TRUE)
-#  speed_calibration            :float            default(1.0)
-#  last_observation_received_at :datetime
-#
-
-# NB! when getting a station use the Friendly ID method Station.friendly.find(params[:id])
-# Stations can use either slug or id as param
+# @attr id  [Integer]
+# @attr name [String]
+# @attr hw_id [String]
+# @attr latitude [Float]
+# @attr longitude [Float]
+# @attr balance [Float]  the balance on prepaid phone cards
+# @attr offline [Boolean]
+# @attr timezone [String]
+# @attr user_id [Integer]
+# @attr created_at [DateTime]
+# @attr updated_at [DateTime]
+# @attr slug [String]  a URL friendly version of the name. Can be used instead of ID.
+# @attr show [Boolean]
+# @attr speed_calibration [Float] 
+# @attr last_observation_received_at [DateTime]
+# @attr sampling_rate [Integer]  - how often a station can be expected to send observations
+# @see https://github.com/norman/friendly_id
+# @note When getting a station use the Friendly ID method!
+#       Station.friendly.find(params[:id])
+#       Since stations can use either the slug or id as param
 class Station < ActiveRecord::Base
 
   # relations

--- a/app/models/station.rb
+++ b/app/models/station.rb
@@ -37,6 +37,7 @@ class Station < ActiveRecord::Base
   #validates_presence_of :hw_id
   validates_numericality_of :speed_calibration
   validates_numericality_of :balance, allow_blank: true
+  validates_numericality_of :sampling_rate, allow_blank: true, max: 24.hours.to_i
 
   # geolocation
   geocoded_by :name
@@ -196,10 +197,10 @@ class Station < ActiveRecord::Base
 
   def next_observation_expected_in
     if last_observation_received_at
-      eta = last_observation_received_at.minus_with_coercion(5.minutes.ago).round()
-      return eta.seconds if eta > 0
+      eta = (last_observation_received_at - sampling_rate.ago).round
+    else
+      sampling_rate
     end
-    5.minutes
   end
 
   # Does a select query to fetch observations and manually sets up active record association to avoid n+1 query
@@ -226,5 +227,9 @@ class Station < ActiveRecord::Base
     else
       self[:sampling_rate].seconds
     end
+  end
+
+  def observations_per_day
+    1.day / sampling_rate
   end
 end

--- a/app/models/station.rb
+++ b/app/models/station.rb
@@ -147,7 +147,7 @@ class Station < ActiveRecord::Base
   # do heuristics if station is down
   def should_be_offline?
       observations.desc
-                 .since(24.minutes.ago)
+                 .since( (sampling_rate * 4.8).seconds.ago  )
                  .count < 3
   end
 

--- a/app/models/station.rb
+++ b/app/models/station.rb
@@ -216,4 +216,15 @@ class Station < ActiveRecord::Base
     observations.each { |observation| association.set_inverse_instance(observation) }
     self.observations
   end
+
+  # Custom getter to get the rate as a Duration instead of an integer
+  # @see http://api.rubyonrails.org/classes/ActiveSupport/Duration.html
+  # @return [ActiveSupport::Duration | nil]
+  def sampling_rate(unit: :seconds)
+    if self[:sampling_rate].nil? || self[:sampling_rate].is_a?(ActiveSupport::Duration)
+      self[:sampling_rate]
+    else
+      self[:sampling_rate].seconds
+    end
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,37 +1,30 @@
-# == Schema Information
-#
-# Table name: users
-#
-#  id                     :integer          not null, primary key
-#  email                  :string(255)      default(""), not null
-#  encrypted_password     :string(255)      default("")
-#  reset_password_token   :string(255)
-#  reset_password_sent_at :datetime
-#  remember_created_at    :datetime
-#  sign_in_count          :integer          default(0), not null
-#  current_sign_in_at     :datetime
-#  last_sign_in_at        :datetime
-#  current_sign_in_ip     :string(255)
-#  last_sign_in_ip        :string(255)
-#  created_at             :datetime
-#  updated_at             :datetime
-#  image                  :string(255)
-#  nickname               :string(255)
-#  slug                   :string(255)
-#  timezone               :string(255)
-#  confirmation_token     :string(255)
-#  confirmed_at           :datetime
-#  confirmation_sent_at   :datetime
-#  invitation_token       :string(255)
-#  invitation_created_at  :datetime
-#  invitation_sent_at     :datetime
-#  invitation_accepted_at :datetime
-#  invitation_limit       :integer
-#  invited_by_id          :integer
-#  invited_by_type        :string(255)
-#  invitations_count      :integer          default(0)
-#
-
+# @attr email [String]  the default column used for database authentication
+# @attr encrypted_password [String]  used by Devise
+# @attr reset_password_token [String]  used by Devise
+# @attr reset_password_sent_at [DateTime]  used by Devise
+# @attr remember_created_at [DateTime]  used by Devise
+# @attr sign_in_count [Integer]  used by Devise trackable
+# @attr current_sign_in_at [DateTime]  used by Devise trackable
+# @attr last_sign_in_at [DateTime]  used by Devise trackable
+# @attr current_sign_in_ip [String]  used by Devise trackable
+# @attr last_sign_in_ip [String]  used by Devise trackable
+# @attr created_at [DateTime]
+# @attr updated_at [DateTime]
+# @attr image [String]  a url to an avatar - not currently in use
+# @attr nickname [String]  allows users to display something else than their email
+# @attr slug [String]  URL friendly version of name that can be used as a route param
+# @attr timezone [String]
+# @attr confirmation_token [String]  used by Devise Confirmable
+# @attr confirmed_at [DateTime]  used by Devise Confirmable
+# @attr confirmation_sent_at [DateTime]  used by Devise Confirmable
+# @attr invitation_token [String]  used by Devise Invitable
+# @attr invitation_created_at [DateTime]  used by Devise Invitable
+# @attr invitation_sent_at [DateTime]   used by Devise Invitable
+# @attr invitation_accepted_at [DateTime]  used by Devise Invitable
+# @attr invitation_limit [Integer]  used by Devise Invitable
+# @attr invited_by_id [Integer]  used by Devise Invitable
+# @attr invited_by_type [String]  used by Devise Invitable
+# @attr invitations_count [Integer]  used by Devise Invitable
 class User < ActiveRecord::Base
   rolify
   # Include default devise modules. Others available are:

--- a/app/models/user_authentication.rb
+++ b/app/models/user_authentication.rb
@@ -1,18 +1,14 @@
-# == Schema Information
-#
-# Table name: user_authentications
-#
-#  id                         :integer          not null, primary key
-#  user_id                    :integer
-#  authentication_provider_id :integer
-#  uid                        :string(255)
-#  token                      :string(255)
-#  token_expires_at           :datetime
-#  params                     :text
-#  created_at                 :datetime
-#  updated_at                 :datetime
-#  provider_name              :string(255)
-#
+# Used to store user oauth authentications
+# @attr id [Integer]
+# @attr user_id [Integer]
+# @attr authentication_provider_id [Integer]
+# @attr uid [String]
+# @attr token [String]
+# @attr token_expires_at [DateTime]
+# @attr params [String]
+# @attr created_at [DateTime] 
+# @attr updated_at [DateTime]
+# @attr provider_name [String]
 
 class UserAuthentication < ActiveRecord::Base
   belongs_to :user
@@ -31,10 +27,7 @@ class UserAuthentication < ActiveRecord::Base
       token_expires_at: Time.at(params['credentials']['expires_at']).to_datetime,
       params: params,
     )
-
   end
 
   alias :provider :authentication_provider
-
-
 end

--- a/app/serializers/observation_serializer.rb
+++ b/app/serializers/observation_serializer.rb
@@ -1,18 +1,4 @@
-# == Schema Information
-#
-# Table name: observations
-#
-#  id                :integer          not null, primary key
-#  station_id        :integer
-#  speed             :float
-#  direction         :float
-#  max_wind_speed    :float
-#  min_wind_speed    :float
-#  temperature       :float
-#  created_at        :datetime
-#  updated_at        :datetime
-#  speed_calibration :float
-#
+# Emits observations as JSON
 class ObservationSerializer < ActiveModel::Serializer
   attributes :id, :station_id, :speed, :direction, :max_wind_speed, :min_wind_speed, :cardinal
 

--- a/app/serializers/station_serializer.rb
+++ b/app/serializers/station_serializer.rb
@@ -1,21 +1,22 @@
+# Emits observations as JSON
 class StationSerializer < ActiveModel::Serializer
   attributes :id, :latitude, :longitude, :name, :slug, :path, :offline, :observations
   private
-
-  # Prevents memory issues if observations have not been preloaded
-  def observations
-    if object.observations.loaded?
-      object.observations
-    else
-      object.load_observations!(10)
+    # Prevents memory issues if observations have not been preloaded
+    # @todo CLEANUP is this still neeeded?
+    def observations
+      if object.observations.loaded?
+        object.observations
+      else
+        object.load_observations!(10)
+      end
     end
-  end
 
-  def offline
-    object.offline?
-  end
+    def offline
+      object.offline?
+    end
 
-  def path
-    station_path(object)
-  end
+    def path
+      station_path(object)
+    end
 end

--- a/app/services/notifiers/station_event_notifier.rb
+++ b/app/services/notifiers/station_event_notifier.rb
@@ -1,15 +1,16 @@
 module Services
   module Notifiers
-    # Notifies owner when a station has a low balance on the prepaid SIM card.
+    # Used to constuct notifiers
+    # @abstract
     class StationEventNotifier
       def self.message(station)
-        raise 'StationEventNotifier subclasses must implement the .message class method'
+        raise NotImplementedError not_impemented_msg(__method__)
       end
 
       def self.event
-        raise 'StationEventNotifier subclasses must implement the .event class method'
+        raise NotImplementedError not_impemented_msg(__method__)
       end
-      
+
       def self.level
         :info
       end
@@ -38,6 +39,11 @@ module Services
           )
         end
       end
+
+      private
+        def not_impemented_msg(method)
+          "StationEventNotifier subclasses must implement .#{method}"
+        end
     end
   end
 end

--- a/app/services/notifiers/station_offline.rb
+++ b/app/services/notifiers/station_offline.rb
@@ -1,6 +1,6 @@
 module Services
   module Notifiers
-    # Notifies owner when a station has a low balance on the prepaid SIM card.
+    # Notifies owner when a station has gone offline
     class StationOffline < StationEventNotifier
       def self.message(station)
         "Your station #{station.name} has not responded for 15 minutes."

--- a/app/services/notifiers/station_online.rb
+++ b/app/services/notifiers/station_online.rb
@@ -1,6 +1,6 @@
 module Services
   module Notifiers
-    # Notifies owner when a station has a low balance on the prepaid SIM card.
+    # Notifies owner when a station is back online.
     class StationOnline < StationEventNotifier
       def self.message(station)
         "Your station #{station.name} has started to respond and we are now receiving data from it."

--- a/app/services/services.rb
+++ b/app/services/services.rb
@@ -1,1 +1,4 @@
-module Services; end
+module Services
+  class NotImplementedError
+  end
+end

--- a/app/views/stations/_form.html.erb
+++ b/app/views/stations/_form.html.erb
@@ -14,6 +14,7 @@
     <% end %>
     <%= f.input(:show) %>
     <%= f.input(:speed_calibration,  min: 0, max: 10, step: 0.01) %>
+    <%= f.input(:sampling_rate,  min: 0, max: 10, step: 0.01) %>
     <div class="actions">
       <%= f.submit %>
     </div>

--- a/app/views/stations/_meta.html.erb
+++ b/app/views/stations/_meta.html.erb
@@ -50,5 +50,9 @@
         <td>Speed Calibration</td>
         <td><%= @station.speed_calibration.round(2) %></td>
       </tr>
+      <tr class="sampling-rate">
+        <td>Sampling Rate</td>
+        <td><%= readable_duration( @station.sampling_rate ) %></td>
+      </tr>
   </tbody>
 </table>

--- a/db/migrate/20161005143212_add_sampling_rate_to_stations.rb
+++ b/db/migrate/20161005143212_add_sampling_rate_to_stations.rb
@@ -1,0 +1,7 @@
+class AddSamplingRateToStations < ActiveRecord::Migration
+  def change
+    # The sampling_rate expessed in seconds
+    # 300s = 5min
+    add_column :stations, :sampling_rate, :integer, default: 300
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160108152623) do
+ActiveRecord::Schema.define(version: 20161005143212) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -90,6 +90,7 @@ ActiveRecord::Schema.define(version: 20160108152623) do
     t.string   "firmware_version"
     t.string   "gsm_software"
     t.string   "description"
+    t.integer  "sampling_rate",     default: 300
   end
 
   add_index "stations", ["hw_id"], name: "index_stations_on_hw_id", unique: true, using: :btree

--- a/readme.md
+++ b/readme.md
@@ -16,6 +16,12 @@ See the [project wiki](https://github.com/remote-wind/remote-wind/wiki) for more
 - If you are using RVM, it should autodetect the ruby version and gemset when you cd into directory
 - bundle install
 
+## Documentation
+The API Documentation is written with [YARD](http://yardoc.org/). You can run the Yard server to view the documentation locally with:
+```bash
+yard server --reload
+```
+
 ### Having problems with bundle install on OS-X?
 The libv8 gem often has problems installing on OS-X due to the lack of openssl
 headers. What seems to work is using the system version of v8. `bundle config build.libv8 -- --with-system-v8`.

--- a/spec/features/stations_spec.rb
+++ b/spec/features/stations_spec.rb
@@ -104,4 +104,12 @@ feature "Stations", %{
       expect(station.observations.count).to eq 0
     end
   end
+
+  scenario "when I change the sampling rate" do
+    admin_session
+    visit edit_station_path(station)
+    fill_in 'Sampling rate', with: 600
+    click_button 'Update'
+    expect(page).to have_content "00:10:00"
+  end
 end

--- a/spec/helpers/stations_helper_spec.rb
+++ b/spec/helpers/stations_helper_spec.rb
@@ -40,12 +40,16 @@ describe StationsHelper, type: :helper do
   end
 
   describe "#station_coordinates" do
-
     let(:station) { build_stubbed(:station, lat: 50, lon: 40) }
     subject(:data_attrs) { helper.station_coordinates(station) }
-
     it { is_expected.to match 'data-lat="50"' }
     it { is_expected.to match 'data-lng="40"' }
+  end
 
+  describe "#readable_duration" do
+    let(:duration) { 1.hour + 5.minutes + 10.seconds }
+    it "includes hours seconds and minutes" do
+      expect(helper.readable_duration(duration)).to eq '01:05:10'
+    end
   end
 end

--- a/spec/models/station_spec.rb
+++ b/spec/models/station_spec.rb
@@ -169,6 +169,24 @@ describe Station, type: :model do
         expect(station.should_be_offline?).to be_truthy
       end
     end
+
+    describe "sampling rate" do
+      let!(:observations) do
+        [*1..4].map do |i|
+          create(:observation, station: station, created_at: (i*10).minutes.ago)
+        end
+      end
+
+      it "takes the sampling_rate into account" do
+        station.sampling_rate = 5.minutes
+        expect(station.should_be_offline?).to eq true
+      end
+
+      it "takes the sampling_rate into account 2" do
+        station.sampling_rate = 10.minutes
+        expect(station.should_be_offline?).to eq false
+      end
+    end
   end
 
   describe "check_status!" do

--- a/spec/models/station_spec.rb
+++ b/spec/models/station_spec.rb
@@ -302,13 +302,13 @@ describe Station, type: :model do
 
   describe "#next_observation_expected_in" do
     let(:station){ build_stubbed(:station) }
-    it "should give number of seconds until next observation" do
+    it "gives number of seconds until next observation" do
       allow(station).to receive(:last_observation_received_at).and_return(2.minutes.ago)
       expect(station.next_observation_expected_in).to eq 3.minutes
     end
-    it "should never give more than 5 minutes" do
+    it "gives a negative number if overdue" do
       allow(station).to receive(:last_observation_received_at).and_return(10.minutes.ago)
-      expect(station.next_observation_expected_in).to eq 5.minutes
+      expect(station.next_observation_expected_in).to eq -5.minutes
     end
   end
 
@@ -392,4 +392,8 @@ describe Station, type: :model do
     it { should be_a ActiveSupport::Duration }
   end
 
+  describe "#observations_per_day" do
+    subject{ build_stubbed(:station, sampling_rate: 1.hour) }
+    its(:observations_per_day) { should eq 24 }
+  end
 end

--- a/spec/models/station_spec.rb
+++ b/spec/models/station_spec.rb
@@ -368,4 +368,10 @@ describe Station, type: :model do
   #   end
   # end
 
+  describe '#sampling_rate' do
+    let(:station) { build_stubbed(:station)  }
+    subject { station.sampling_rate }
+    it { should be_a ActiveSupport::Duration }
+  end
+
 end


### PR DESCRIPTION
This PR is basically an attempt to make sure that the "public API" of the app (as in the public methods - not the HTTP API) is documented and properly formatted for [YARD](http://yardoc.org/).
It also cleans up numerous style violations (such as method definitions without parens) and marks quite a few areas needing further cleanup (with @todo tags). 

Sorry for the monster commit but there are very few actual code changes. Just comments.