### PR TITLE
122 station enums

### DIFF
--- a/app/assets/javascripts/stations/map.js.erb
+++ b/app/assets/javascripts/stations/map.js.erb
@@ -120,7 +120,7 @@ $(document).ready(function(){
             href: station.path,
             zIndex: 50
         };
-        if (station.offline) {
+        if (station.status !== 'active') {
             options.icon = remotewind.icons.station_down();
         } else {
             options.icon = remotewind.icons.station(observation);
@@ -156,8 +156,8 @@ $(document).ready(function(){
                     map: map,
                     text: (function (station) {
                         var str = station.name + "<br>";
-                        if (station.offline) {
-                            str += " Offline";
+                        if (station.status !== 'active') {
+                            str += station.status;
                         } else if (observation) {
                             str += observation.speed + "(" + observation.min_wind_speed + "-" + observation.max_wind_speed + ")  m/s";
                         }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -86,4 +86,6 @@ class ApplicationController < ActionController::Base
       self.headers['Access-Control-Allow-Methods'] = methods
       self.headers['Access-Control-Allow-Headers'] = headers
     end
+
+
 end

--- a/app/controllers/observations_controller.rb
+++ b/app/controllers/observations_controller.rb
@@ -74,7 +74,6 @@ class ObservationsController < ApplicationController
 
     # get station with Friendly ID as params[:id] can either be id or slug
     def set_station
-
       @station = Station.friendly.find(params[:station_id])
     end
 

--- a/app/controllers/stations_controller.rb
+++ b/app/controllers/stations_controller.rb
@@ -186,7 +186,8 @@ class StationsController < ApplicationController
     def station_params
       params.require(:station).permit(
         :name, :hw_id, :latitude, :longitude, :user_id, :slug,
-        :show, :speed_calibration, :description, :sampling_rate
+        :show, :speed_calibration, :description, :sampling_rate,
+        :status
       )
     end
 end

--- a/app/controllers/stations_controller.rb
+++ b/app/controllers/stations_controller.rb
@@ -154,13 +154,15 @@ class StationsController < ApplicationController
   # Used by Ardiuno to lookup station ID
   def find
     @station = Station.find_by(hw_id: params[:hw_id])
-    if(@station.nil?)
+    if @station.nil?
       respond_to do |format|
         format.json { head :not_found }
       end
     else
+      # Update station to show that it has been intialized
+      @station.unresponsive! if @station.not_initialized?
       respond_to do |format|
-        format.json { render json: { id: @station.id }}
+        format.json { render json: { id: @station.id } }
       end
     end
   end

--- a/app/controllers/stations_controller.rb
+++ b/app/controllers/stations_controller.rb
@@ -26,6 +26,7 @@ class StationsController < ApplicationController
       end
 
       @stations = @stations.with_observations(1)
+
       @stations.load
       respond_to do |format|
         format.html

--- a/app/helpers/stations_helper.rb
+++ b/app/helpers/stations_helper.rb
@@ -18,15 +18,16 @@ module StationsHelper
 
   # @param station [Station]
   # @return [String]
-  # @example when online
+  # @example when status == active
   #   station_header(station)
   #   => "Test station"
-  # @example when offline
+  # @example when status == "not_initialized"
+  # @todo Use i18n to translate statuses
   #   station_header(station)
-  #   => "Test station(<em>offline</em>)"
+  #   => "Test station(<em>not initalized</em>)"
   def station_header(station)
-    if station.offline?
-      ( station.name + "(#{content_tag(:em, 'offline')})" ).html_safe
+    unless station.active?
+      ( station.name + "(#{content_tag(:em, station.status.titleize.downcase )})" ).html_safe
     else
       station.name
     end
@@ -36,7 +37,10 @@ module StationsHelper
   # @param station [Station]
   # @return [String]
   def station_coordinates(station)
-    sprintf('data-lat="%d" data-lng="%d"', station.latitude, station.longitude).html_safe
+    sprintf(
+      'data-lat="%d" data-lng="%d"',
+      station.latitude,
+      station.longitude).html_safe
   end
 
   # Displays a duration as a digital timer format

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -5,11 +5,9 @@
 class Ability
   include CanCan::Ability
 
-  attr_accessor :user
-
   # @param [User] user
   def initialize(user)
-    @user ||= User.new
+    user ||= User.new
 
     # Use crud alias instead of manage since it can grant invitation access for example.
     alias_action :create, :read, :update, :destroy,

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -5,9 +5,11 @@
 class Ability
   include CanCan::Ability
 
+  attr_accessor :user
+
   # @param [User] user
   def initialize(user)
-    user ||= User.new
+    @user ||= User.new
 
     # Use crud alias instead of manage since it can grant invitation access for example.
     alias_action :create, :read, :update, :destroy,
@@ -17,9 +19,14 @@ class Ability
 
     can :read, User
     can :read, Role
-    can :read, Station do |s|
-      s.show?
+    can :read, Station do |station|
+      if user.has_role?(:owner, station)
+        true # can see any status
+      else
+        station.active? || station.unresponsive?
+      end
     end
+
     can [:update_balance, :api_firmware_version, :find, :embed, :search], Station
     can [:read, :create], Observation
     can :crud, Notification do |note|

--- a/app/models/station.rb
+++ b/app/models/station.rb
@@ -146,21 +146,21 @@ class Station < ActiveRecord::Base
   end
 
   # do heuristics if station is down
-  def should_be_offline?
+  def is_unresponsive?
       observations.desc
                  .since( (sampling_rate * 4.8).seconds.ago  )
                  .count < 3
   end
 
   def check_status!
-    if should_be_offline?
-      unless offline?
-        update_attribute('offline', true)
+    if is_unresponsive?
+      if active?
+        self.unresponsive!
         Services::Notifiers::StationOffline.call(self)
       end
     else
-      if offline?
-        update_attribute('offline', false)
+      unless active?
+        self.active!
         Services::Notifiers::StationOnline.call(self)
       end
     end

--- a/app/models/station.rb
+++ b/app/models/station.rb
@@ -68,9 +68,10 @@ class Station < ActiveRecord::Base
   # @return [ActiveRecord::Relation]
   def self.with_observations(limit = 1)
     eager_load(:observations).where(
-      observations: { id: Observation.pluck_from_each_station(limit) }
-    )
-  end
+      'observations.id is null or observations.id in (?)',
+      Observation.pluck_from_each_station(limit)
+    ).order('observations.created_at DESC')
+  end 
 
   # Setup default values for new records
   after_initialize do

--- a/app/models/station.rb
+++ b/app/models/station.rb
@@ -124,11 +124,7 @@ class Station < ActiveRecord::Base
   end
 
   def observations?
-    if self.observations.loaded?
-      self.observations.length > 0
-    else
-      self.observations.present?
-    end
+    self.observations.any?
   end
 
   def self.send_low_balance_alerts stations = Station.all()

--- a/app/models/station.rb
+++ b/app/models/station.rb
@@ -11,14 +11,17 @@
 # @attr updated_at [DateTime]
 # @attr slug [String]  a URL friendly version of the name. Can be used instead of ID.
 # @attr show [Boolean]
-# @attr speed_calibration [Float] 
+# @attr speed_calibration [Float]
 # @attr last_observation_received_at [DateTime]
 # @attr sampling_rate [Integer]  - how often a station can be expected to send observations
+# @attr status [Integer] enum column
 # @see https://github.com/norman/friendly_id
 # @note When getting a station use the Friendly ID method!
 #       Station.friendly.find(params[:id])
 #       Since stations can use either the slug or id as param
 class Station < ActiveRecord::Base
+  # Denotes the general status of a station
+  enum status: [:not_initialized, :deactivated, :unresponsive, :active]
 
   # relations
   belongs_to :user, inverse_of: :stations

--- a/app/models/station.rb
+++ b/app/models/station.rb
@@ -32,6 +32,13 @@ class Station < ActiveRecord::Base
   has_many :recent_observations, -> { order('created_at ASC').limit(10) }, class_name: 'Observation'
   has_one :current_observation, -> { order('created_at ASC').limit(1) }, class_name: 'Observation'
 
+  # Has scoped roles
+  # @see https://github.com/RolifyCommunity/rolify
+  resourcify
+
+  # Scopes
+  scope :visible, -> { unresponsive.merge(active) }
+
    # constraints
   validates_uniqueness_of :hw_id
   #validates_presence_of :hw_id
@@ -52,12 +59,8 @@ class Station < ActiveRecord::Base
   alias_attribute :lat, :latitude
   alias_attribute :lon, :longitude
   alias_attribute :lng, :longitude
-  alias_attribute :owner, :user
   attr_accessor :zone
   attr_accessor :latest_observation
-
-  # Scopes
-  scope :visible, -> { where( show: true ) }
 
   # Scope that eager loads the latest N number of observations.
   # @note requires Postgres 9.3+

--- a/app/models/station.rb
+++ b/app/models/station.rb
@@ -4,13 +4,11 @@
 # @attr latitude [Float]
 # @attr longitude [Float]
 # @attr balance [Float]  the balance on prepaid phone cards
-# @attr offline [Boolean]
 # @attr timezone [String]
 # @attr user_id [Integer]
 # @attr created_at [DateTime]
 # @attr updated_at [DateTime]
 # @attr slug [String]  a URL friendly version of the name. Can be used instead of ID.
-# @attr show [Boolean]
 # @attr speed_calibration [Float]
 # @attr last_observation_received_at [DateTime]
 # @attr sampling_rate [Integer]  - how often a station can be expected to send observations
@@ -71,7 +69,7 @@ class Station < ActiveRecord::Base
       'observations.id is null or observations.id in (?)',
       Observation.pluck_from_each_station(limit)
     ).order('observations.created_at DESC')
-  end 
+  end
 
   # Setup default values for new records
   after_initialize do

--- a/app/serializers/station_serializer.rb
+++ b/app/serializers/station_serializer.rb
@@ -1,6 +1,7 @@
 # Emits observations as JSON
 class StationSerializer < ActiveModel::Serializer
-  attributes :id, :latitude, :longitude, :name, :slug, :path, :offline, :observations
+  attributes  :id, :latitude, :longitude, :name, :slug, :path,
+              :status, :observations
   private
     # Prevents memory issues if observations have not been preloaded
     # @todo CLEANUP is this still neeeded?
@@ -10,10 +11,6 @@ class StationSerializer < ActiveModel::Serializer
       else
         object.load_observations!(10)
       end
-    end
-
-    def offline
-      object.offline?
     end
 
     def path

--- a/app/views/stations/_form.html.erb
+++ b/app/views/stations/_form.html.erb
@@ -19,3 +19,15 @@
       <%= f.submit %>
     </div>
 <% end %>
+
+<% if @station.persisted? %>
+  <%= simple_form_for @station do |f| %>
+    <% if @station.deactivated?  %>
+      <%= f.hidden_field(:status, value: 'active')  %>
+      <%= f.submit('Activate') %>
+    <% else %>
+      <%= f.hidden_field(:status, value: 'deactivated')  %>
+      <%= f.submit('Deactivate') %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/stations/_meta.html.erb
+++ b/app/views/stations/_meta.html.erb
@@ -10,6 +10,10 @@
         <td><%= time_date_hours_seconds(@station.updated_at_local) %></td>
       </tr>
       <% end %>
+      <tr class="status">
+        <td>Updated</td>
+        <td><%= @station.status %></td>
+      </tr>
       <% if @station.user.present? %>
       <tr class="owner">
         <td>Owner</td>

--- a/app/views/stations/_meta.html.erb
+++ b/app/views/stations/_meta.html.erb
@@ -46,10 +46,6 @@
         <td>GSM Modem firmware</td>
         <td><%= @station.gsm_software %></td>
       </tr>
-      <tr class="visible">
-        <td>Visible</td>
-        <td><%= @station.show ? 'yes' : 'no' %></td>
-      </tr>
       <tr class="speed-calibration">
         <td>Speed Calibration</td>
         <td><%= @station.speed_calibration.round(2) %></td>

--- a/app/views/stations/_stations.html.erb
+++ b/app/views/stations/_stations.html.erb
@@ -23,10 +23,10 @@
           <% end %>
         </td>
         <td>
-          <% unless station.offline? %>
-              <span class="label success">OK</span>
+          <% unless station.active? %>
+              <span class="label success">Active</span>
           <% else %>
-              <span class="label alert">DOWN</span>
+              <span class="label alert"><%= station.status %></span>
           <% end %>
         </td>
       </tr>

--- a/db/migrate/20161024164616_add_status_to_station.rb
+++ b/db/migrate/20161024164616_add_status_to_station.rb
@@ -1,0 +1,6 @@
+class AddStatusToStation < ActiveRecord::Migration
+  def change
+    add_column :stations, :status, :integer, default: 0
+    add_index :stations, :status
+  end
+end

--- a/db/migrate/20161025141457_remove_boolean_columns_from_stations.rb
+++ b/db/migrate/20161025141457_remove_boolean_columns_from_stations.rb
@@ -1,0 +1,8 @@
+class RemoveBooleanColumnsFromStations < ActiveRecord::Migration
+  def change
+    Station.where(offline: true).update_all(status: :unresponsive)
+    Station.where(offline: false).update_all(status: :active)
+    remove_column(:stations, :offline)
+    remove_column(:stations, :show)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161024164616) do
+ActiveRecord::Schema.define(version: 20161025141457) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -79,13 +79,11 @@ ActiveRecord::Schema.define(version: 20161024164616) do
     t.float    "latitude"
     t.float    "longitude"
     t.float    "balance"
-    t.boolean  "offline"
     t.string   "timezone"
     t.integer  "user_id"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "slug"
-    t.boolean  "show",              default: true
     t.float    "speed_calibration", default: 1.0
     t.string   "firmware_version"
     t.string   "gsm_software"
@@ -95,8 +93,6 @@ ActiveRecord::Schema.define(version: 20161024164616) do
   end
 
   add_index "stations", ["hw_id"], name: "index_stations_on_hw_id", unique: true, using: :btree
-  add_index "stations", ["offline"], name: "index_stations_on_offline", using: :btree
-  add_index "stations", ["show"], name: "index_stations_on_show", using: :btree
   add_index "stations", ["slug"], name: "index_stations_on_slug", unique: true, using: :btree
   add_index "stations", ["status"], name: "index_stations_on_status", using: :btree
   add_index "stations", ["updated_at"], name: "index_stations_on_updated_at", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161005143212) do
+ActiveRecord::Schema.define(version: 20161024164616) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -91,12 +91,14 @@ ActiveRecord::Schema.define(version: 20161005143212) do
     t.string   "gsm_software"
     t.string   "description"
     t.integer  "sampling_rate",     default: 300
+    t.integer  "status",            default: 0
   end
 
   add_index "stations", ["hw_id"], name: "index_stations_on_hw_id", unique: true, using: :btree
   add_index "stations", ["offline"], name: "index_stations_on_offline", using: :btree
   add_index "stations", ["show"], name: "index_stations_on_show", using: :btree
   add_index "stations", ["slug"], name: "index_stations_on_slug", unique: true, using: :btree
+  add_index "stations", ["status"], name: "index_stations_on_status", using: :btree
   add_index "stations", ["updated_at"], name: "index_stations_on_updated_at", using: :btree
   add_index "stations", ["user_id"], name: "index_stations_on_user_id", using: :btree
 

--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,7 @@ It is a Rails based REST application.
 
 This open-source project is available under a [GNU GPL v3 license](http://www.gnu.org/copyleft/gpl.html)
 
-See the [project wiki](https://github.com/remote-wind/remote-wind/wiki) for more detailed information.
+See the [project wiki](https://github.com/remote-wind/remote-wind/wiki) for more detailed information and the [documentation](http://www.rubydoc.info/github/remote-wind/remote-wind/).
 
 ### Requirements
 - see Gemfile
@@ -17,7 +17,13 @@ See the [project wiki](https://github.com/remote-wind/remote-wind/wiki) for more
 - bundle install
 
 ## Documentation
-The API Documentation is written with [YARD](http://yardoc.org/). You can run the Yard server to view the documentation locally with:
+Documentation is available at:
+
+http://www.rubydoc.info/github/remote-wind/remote-wind/
+
+The API Documentation is written with [YARD](http://yardoc.org/).
+To run the documentation server locally:
+
 ```bash
 yard server --reload
 ```

--- a/spec/controllers/stations_controller_spec.rb
+++ b/spec/controllers/stations_controller_spec.rb
@@ -415,13 +415,16 @@ describe StationsController, type: :controller do
 
   describe "GET find" do
 
+    let(:station) { create(:station, status: :not_initialized) }
     render_views
 
     let(:json) { JSON.parse(response.body) }
 
-    before do
+    before do |ex|
       station
-      get :find, hw_id: station.hw_id, format: :json
+      unless ex.metadata[:skip_request]
+        get :find, hw_id: station.hw_id, format: :json
+      end
     end
 
     it "should return HTTP success" do
@@ -434,6 +437,14 @@ describe StationsController, type: :controller do
 
     it "contains the id" do
       expect(json["id"]).to eq station.id
+    end
+
+    it "changes the station status" do
+      expect {
+        get :find, hw_id: station.hw_id, format: :json
+        station.reload
+      }.to change(station, :status).from("not_initialized")
+           .to("unresponsive")
     end
   end
 end

--- a/spec/controllers/stations_controller_spec.rb
+++ b/spec/controllers/stations_controller_spec.rb
@@ -25,6 +25,14 @@ describe StationsController, type: :controller do
         get :index, format: 'html'
         expect(first_response['ETag']).to_not eq (response.headers['ETag'])
       end
+
+      it "takes the user into account" do
+        get :index
+        first_response = response.headers.clone
+        sign_in(create(:user))
+        get :index
+        expect(first_response['ETag']).to_not eq (response.headers['ETag'])
+      end
     end
 
     before :each do

--- a/spec/factories/stations.rb
+++ b/spec/factories/stations.rb
@@ -5,7 +5,6 @@ FactoryGirl.define do
     sequence(:name) { |n| "Station #{n}" }
     latitude 51.478885
     longitude -0.010635
-    show true
     balance 1
     status :active
     user

--- a/spec/factories/stations.rb
+++ b/spec/factories/stations.rb
@@ -1,26 +1,4 @@
-# == Schema Information
-#
-# Table name: stations
-#
-#  id                           :integer          not null, primary key
-#  name                         :string(255)
-#  hw_id                        :string(255)
-#  latitude                     :float
-#  longitude                    :float
-#  balance                      :float
-#  offline                      :boolean
-#  timezone                     :string(255)
-#  user_id                      :integer
-#  created_at                   :datetime
-#  updated_at                   :datetime
-#  slug                         :string(255)
-#  show                         :boolean          default(TRUE)
-#  speed_calibration            :float            default(1.0)
-#  last_observation_received_at :datetime
-#
-
 # Read about factories at https://github.com/thoughtbot/factory_girl
-
 FactoryGirl.define do
   factory :station do
     sequence(:hw_id) { |n| "hw_id_#{n}" }
@@ -29,7 +7,7 @@ FactoryGirl.define do
     longitude -0.010635
     show true
     balance 1
-    offline nil
+    status :active
     user
     speed_calibration 1
   end

--- a/spec/features/stations_spec.rb
+++ b/spec/features/stations_spec.rb
@@ -7,14 +7,7 @@ feature "Stations", %{
 
   let(:station) { create(:station, status: :active) }
   let(:observation) { station.observations.create(attributes_for(:observation)) }
-
-  let(:stations) do
-    [*1..3].map! do |i|
-      station = create(:station, name: "Station #{i+1}")
-      station.observations.create attributes_for(:observation)
-      station
-    end
-  end
+  let(:stations) { create_list(:station, 3) }
 
   let(:admin) { create :admin }
   let(:admin_session) { sign_in! admin }
@@ -76,21 +69,24 @@ feature "Stations", %{
     expect(page).to have_content 'Station at the End of The World'
   end
 
-  scenario "when I view index I should not see hidden stations" do
-    station = create(:station, show: false)
-    visit stations_path
-    expect(page).to_not have_link station.name
-  end
+  context "hidden stations" do
+    let!(:deactivated_station) { create(:station, status: :deactivated) }
+    let!(:new_station) { create(:station, status: :not_initialized) }
 
-  scenario "when I am signed in as an admin and view index I should see hidden stations" do
-    skip %Q{
-      This works when I manually check in browser but for some reason capybara gets a document without any
-      stations at all. I must be missing something
-    }
-    admin_session
-    #station = create(:station, show: false)
-    #visit stations_path
-    #expect(page).to have_link station.name
+    scenario "when I view index I should not see hidden stations" do
+      station =
+      station2 = create(:station, status: :not_initialized)
+      visit stations_path
+      expect(page).to_not have_link deactivated_station.name
+      expect(page).to_not have_link new_station.name
+    end
+
+    scenario "when I am signed in as an admin and view index I should see hidden stations" do
+      admin_session
+      visit stations_path
+      expect(page).to have_link deactivated_station.name
+      expect(page).to have_link new_station.name
+    end
   end
 
   context "given a station with observations" do

--- a/spec/features/stations_spec.rb
+++ b/spec/features/stations_spec.rb
@@ -112,4 +112,20 @@ feature "Stations", %{
     click_button 'Update'
     expect(page).to have_content "00:10:00"
   end
+
+  scenario "when I deactivate a station" do
+    admin_session
+    visit edit_station_path(station)
+    click_button 'Deactivate'
+    expect(page).to have_content "deactivated"
+  end
+
+  scenario "when I reactivate a station" do
+    admin_session
+    visit edit_station_path(station)
+    click_button 'Deactivate'
+    click_link 'Edit'
+    click_button 'Activate'
+    expect(page).to have_content "active"
+  end
 end

--- a/spec/features/stations_spec.rb
+++ b/spec/features/stations_spec.rb
@@ -5,7 +5,7 @@ feature "Stations", %{
   and  editable by admins
 } do
 
-  let(:station) { create :station }
+  let(:station) { create(:station, status: :active) }
   let(:observation) { station.observations.create(attributes_for(:observation)) }
 
   let(:stations) do

--- a/spec/helpers/stations_helper_spec.rb
+++ b/spec/helpers/stations_helper_spec.rb
@@ -34,7 +34,7 @@ describe StationsHelper, type: :helper do
     context "when station is not active" do
       let(:station) { build_stubbed(:station, status: :deactivated) }
       subject(:heading)  { helper.station_header(station) }
-      it "says 'offline'" do
+      it "shows the stations status" do
         expect(heading).to have_selector 'em', text: 'deactivated'
       end
     end

--- a/spec/helpers/stations_helper_spec.rb
+++ b/spec/helpers/stations_helper_spec.rb
@@ -31,10 +31,11 @@ describe StationsHelper, type: :helper do
       expect(heading).to eq (station.name)
     end
 
-    context "when station is down" do
-      subject(:heading)  { helper.station_header(build_stubbed(:station, offline: true)) }
+    context "when station is not active" do
+      let(:station) { build_stubbed(:station, status: :deactivated) }
+      subject(:heading)  { helper.station_header(station) }
       it "says 'offline'" do
-        expect(heading).to have_selector 'em', text: 'offline'
+        expect(heading).to have_selector 'em', text: 'deactivated'
       end
     end
   end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -17,22 +17,34 @@ describe Ability, type: :model do
     it "should not be able to manage others" do
       expect(subject).to_not be_able_to(:manage, User)
     end
-    it { is_expected.to be_able_to(:crud, auth) }
-    it { is_expected.not_to be_able_to(:crud, build_stubbed(:user_authentication, user: build_stubbed(:user))) }
-    it { is_expected.to be_able_to(:read, Station) }
-    it { is_expected.to be_able_to(:find, Station) }
-    it { is_expected.to be_able_to(:read, Observation) }
-    it { is_expected.to be_able_to(:create, Observation) }
-    it { is_expected.to be_able_to(:read, notification) }
-    it { is_expected.to be_able_to(:destroy, notification) }
+    it { should be_able_to(:crud, auth) }
+    it { should_not be_able_to(:crud, build_stubbed(:user_authentication, user: build_stubbed(:user))) }
+
+    describe "stations" do
+      def stn(status)
+        build_stubbed(:station, status: status)
+      end
+
+      it { should be_able_to( :read, stn(:active) ) }
+      it { should be_able_to( :read, stn(:unresponsive) ) }
+      it { should_not be_able_to( :read, stn(:not_initialized) ) }
+      it { should_not be_able_to( :read, stn(:deactivated) ) }
+    end
+
+    it { should be_able_to(:read, Station) }
+    it { should be_able_to(:find, Station) }
+    it { should be_able_to(:read, Observation) }
+    it { should be_able_to(:create, Observation) }
+    it { should be_able_to(:read, notification) }
+    it { should be_able_to(:destroy, notification) }
   end
 
   context "an admin" do
     before do
       allow_any_instance_of(User).to receive(:has_role?).with(:admin).and_return(true)
     end
-    it { is_expected.to be_able_to(:manage, User) }
-    it { is_expected.to be_able_to(:manage, UserAuthentication) }
-    it { is_expected.to be_able_to(:manage, Station) }
+    it { should be_able_to(:manage, User) }
+    it { should be_able_to(:manage, UserAuthentication) }
+    it { should be_able_to(:manage, Station) }
   end
 end

--- a/spec/models/observation_spec.rb
+++ b/spec/models/observation_spec.rb
@@ -31,33 +31,8 @@ describe Observation, type: :model do
     end
 
     describe "aliases" do
-      it { is_expected.to respond_to :i }
-      it { is_expected.to respond_to :s }
-      it { is_expected.to respond_to :d }
       it { is_expected.to respond_to :max }
       it { is_expected.to respond_to :min }
-    end
-  end
-
-  describe "Ardiuno adapted setters should" do
-    specify "normalize speed" do
-      expect(Observation.new(s: 100).speed).to eq 1
-    end
-
-    specify "normalize direction" do
-      expect(Observation.new(d: 100).direction).to eq 10
-    end
-
-    specify "round direction properly" do
-      expect(Observation.new(d: "2838").direction).to eq 284
-    end
-
-    specify "normalize min" do
-      expect(Observation.new(min: 100).min).to eq 1
-    end
-
-    specify "normalize max" do
-      expect(Observation.new(max: 100).max).to eq 1
     end
   end
 

--- a/spec/models/station_spec.rb
+++ b/spec/models/station_spec.rb
@@ -263,7 +263,7 @@ describe Station, type: :model do
         end
 
         it "should not send message" do
-          expect(Services::Notifiers::StationOnline).to_not receive(:call).with(station)
+          expect(Services::Notifiers::StationOnline).not_to receive(:call).with(station)
           station.check_status!
         end
 

--- a/spec/models/station_spec.rb
+++ b/spec/models/station_spec.rb
@@ -1,24 +1,3 @@
-# == Schema Information
-#
-# Table name: stations
-#
-#  id                           :integer          not null, primary key
-#  name                         :string(255)
-#  hw_id                        :string(255)
-#  latitude                     :float
-#  longitude                    :float
-#  balance                      :float
-#  offline                      :boolean
-#  timezone                     :string(255)
-#  user_id                      :integer
-#  created_at                   :datetime
-#  updated_at                   :datetime
-#  slug                         :string(255)
-#  show                         :boolean          default(TRUE)
-#  speed_calibration            :float            default(1.0)
-#  last_observation_received_at :datetime
-#
-
 require 'spec_helper'
 require 'timezone/error'
 

--- a/spec/models/station_spec.rb
+++ b/spec/models/station_spec.rb
@@ -39,12 +39,11 @@ describe Station, type: :model do
       it { is_expected.to respond_to :owner }
     end
 
-=begin
+
     it {
       should define_enum_for(:status)
                .with([:not_initialized, :deactivated, :unresponsive, :active])
     }
-=end
   end
 
   describe "validations" do

--- a/spec/models/station_spec.rb
+++ b/spec/models/station_spec.rb
@@ -36,7 +36,6 @@ describe Station, type: :model do
       it { is_expected.to respond_to :lon }
       it { is_expected.to respond_to :lng }
       it { is_expected.to respond_to :lat }
-      it { is_expected.to respond_to :owner }
     end
 
     it do

--- a/spec/requests/stations_spec.rb
+++ b/spec/requests/stations_spec.rb
@@ -15,19 +15,30 @@ RSpec.describe "Stations", type: :request do
     end
   end
 
-  describe "GET /stations.json" do
-    let(:observation) { json.first["observations"].first }
-    before do
-      [20, 15, 10, 5, 0].map do |time|
-        Timecop.travel( time.minutes.ago ) do
-          station.observations.create( attributes_for(:observation) )
+  describe "GET /stations" do
+
+    context 'with observations' do
+      let(:observation) { json.first["observations"].first }
+      before do
+        [20, 15, 10, 5, 1].map do |time|
+          Timecop.travel( time.minutes.ago ) do
+            station.observations.create( attributes_for(:observation) )
+          end
         end
+      end
+
+      it "should include the correct observation" do
+        get '/stations.json'
+        expect(observation["id"]).to eq station.observations.last.id
       end
     end
 
-    it "should include the correct observation" do
+    it 'includes stations with no observations' do
+      station
       get '/stations.json'
-      expect(observation["id"]).to eq station.observations.last.id
+      expect(json.first['id']).to eq station.id
     end
   end
+
+
 end

--- a/spec/requests/stations_spec.rb
+++ b/spec/requests/stations_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 RSpec.describe "Stations", type: :request do
 
-  let(:station){ create(:station) }
+  let(:station){ create(:station, status: :active) }
   let(:json) { JSON.parse(response.body) }
 
   describe "GET /stations/find/:hw_id" do
@@ -23,7 +23,7 @@ RSpec.describe "Stations", type: :request do
           station.observations.create( attributes_for(:observation) )
         end
       end
-    end 
+    end
 
     it "should include the correct observation" do
       get '/stations.json'

--- a/spec/serializers/station_serializer_spec.rb
+++ b/spec/serializers/station_serializer_spec.rb
@@ -22,6 +22,6 @@ describe StationSerializer do
     expect(subject.path).to eq station_path(resource)
   end
   it "has the correct offline attribute" do
-    expect(subject.offline).to eq resource.offline?
+    expect(subject.status).to eq resource.status
   end
 end

--- a/spec/serializers/station_serializer_spec.rb
+++ b/spec/serializers/station_serializer_spec.rb
@@ -21,7 +21,7 @@ describe StationSerializer do
   it "has the correct path" do
     expect(subject.path).to eq station_path(resource)
   end
-  it "has the correct offline attribute" do
+  it "has the correct status" do
     expect(subject.status).to eq resource.status
   end
 end


### PR DESCRIPTION
This greatly cleans up the logic around how stations are displayed - and fixes several bugs including #138.

Make sure to run `rake db:migrate` as this adds a column to the stations table and removes two others. 
