### PR TITLE
handle case where user does not have a nickname

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -69,4 +69,9 @@ class User < ActiveRecord::Base
       false
     end
   end
+
+  # @return [String]
+  def display_name
+    nickname.present? ? nickname : email.split("@").first
+  end
 end

--- a/app/views/stations/_meta.html.erb
+++ b/app/views/stations/_meta.html.erb
@@ -14,12 +14,6 @@
         <td>Updated</td>
         <td><%= @station.status %></td>
       </tr>
-      <% if @station.user.present? %>
-      <tr class="owner">
-        <td>Owner</td>
-        <td><%= link_to(@station.user.nickname, user_path(@station.user)) %></td>
-      </tr>
-      <% end %>
       <% unless @station.last_observation_received_at.nil? %>
       <tr class="last-observation-received-at">
         <td>Last data recieved at</td>

--- a/spec/features/stations_spec.rb
+++ b/spec/features/stations_spec.rb
@@ -193,5 +193,13 @@ RSpec.feature "Stations" do
     expect(page).to have_content 'Europe/Copenhagen'
     station.reload
     expect(station.timezone).to eq 'Europe/Copenhagen'
+  end 
+
+  scenario "when I click on the station owner" do
+    admin_session
+    visit station_path(station)
+    save_and_open_page
+    click_link(station.user.display_name)
+    expect(current_path).to include user_path(station.user)
   end
 end


### PR DESCRIPTION
Quick fix for a bug where stations show a path instead of the users name if they don't have a nickname. Should perhaps be done by setting a default value in a callback such as using the left hand part of the email.